### PR TITLE
Fixed issue with OnSelectCard

### DIFF
--- a/Game/GameAI.cs
+++ b/Game/GameAI.cs
@@ -172,8 +172,10 @@ namespace WindBot.Game
             // Always select the first available cards and choose the minimum.
             IList<ClientCard> selected = new List<ClientCard>();
 
-            for (int i = 0; i < min; ++i)
-                selected.Add(cards[i]);
+            if (cards.Count() >= min) {
+                for (int i = 0; i < min; ++i)
+                    selected.Add(cards[i]);
+            }
 
             return selected;
         }


### PR DESCRIPTION
This function has been reported to generate _System.ArgumentOutOfRangeException_ multiple times. Judging from the exception logs, I suspect the issue is in the _for_ loop that populates _selected_ at the end: it tries to add the first _min_ elements of _cards_, but it doesn't check whether _cards_ has that many elements beforehand, and this leads to the exception when it tries to access an element beyond _cards_'s size. If that's the issue, it could be fixed by adding a check before the _for_ loop, making it loop only if _cards_ has at least _min_ elements: if not, it should return _selected_ as an empty list. I'm not sure if this is the correct behaviour it should add, though, so I'll leave this pull to be reviewed.